### PR TITLE
WIP: Add Let's Encrypt via certbot-nginx plugin

### DIFF
--- a/server-provision.yml
+++ b/server-provision.yml
@@ -266,6 +266,7 @@
       changed_when: "'Running post-hook command' in certbot_output.stdout"
       become: true
       become_user: root
+      when: use_lets_encrypt
 
     - name: Set Letsencrypt Cronjob for Certificate Auto Renewal
       cron:
@@ -273,6 +274,7 @@
         special_time: monthly
         job: "/usr/bin/certbot renew"
       when: ansible_facts['os_family'] == "Debian"
+      when: use_lets_encrypt
 
     - name: Restart nginx service
       service:

--- a/server-provision.yml
+++ b/server-provision.yml
@@ -89,7 +89,7 @@
       apt:
         update_cache: yes
 
-    - name: Install dependencies for compiling Ruby along with Node.js and Yarn
+    - name: Install dependencies for compiling Ruby, Node.js, Yarn and Certbot
       apt:
         state: present
         name:
@@ -115,8 +115,9 @@
           - redis-tools
           - nodejs
           - yarn
+          - python3-certbot-nginx
 
-- name: Log in as deploy user and setup ruby, passenger and nginx
+- name: Log in as deploy user and setup ruby, passenger, nginx and certbot
   hosts: web
   vars_files:
     - vars/vars.yml
@@ -255,6 +256,24 @@
       become: true
       become_user: root
 
+    - name: Create and Install Cert Using Nginx Plugin
+      command: >-
+         certbot --nginx {% for host in certbot_domains %}  -d {{ host }} {% endfor %}
+         -m {{ certbot_email }}
+         --agree-tos --noninteractive --redirect
+         --post-hook "/bin/true"
+      register: certbot_output
+      changed_when: "'Running post-hook command' in certbot_output.stdout"
+      become: true
+      become_user: root
+
+    - name: Set Letsencrypt Cronjob for Certificate Auto Renewal
+      cron:
+        name: letsencrypt_renewal
+        special_time: monthly
+        job: "/usr/bin/certbot renew"
+      when: ansible_facts['os_family'] == "Debian"
+
     - name: Restart nginx service
       service:
         name: nginx
@@ -263,7 +282,7 @@
       become_user: root
 
     - name: Let deploy user restart passenger without sudo
-      template: 
+      template:
         src: templates/sudoers_passenger.j2
         dest: /etc/sudoers.d/passenger
         validate: 'visudo -cf %s'
@@ -329,7 +348,7 @@
         group: "{{ deploy_user }}"
 
     - name: Copy sidekiq service file to user service
-      template: 
+      template:
         src: templates/sidekiq.service.j2
         dest: "/home/{{ deploy_user }}/.config/systemd/user/sidekiq.service"
 

--- a/templates/nginx_app.conf.j2
+++ b/templates/nginx_app.conf.j2
@@ -4,7 +4,7 @@ server {
   listen 80;
   listen [::]:80;
 
-  server_name _;
+  server_name {{ certbot_domains | join(' ') }};
   root /home/{{ deploy_user }}/{{ app_name }}/current/public;
 
   passenger_enabled on;

--- a/templates/nginx_app.conf.j2
+++ b/templates/nginx_app.conf.j2
@@ -4,7 +4,11 @@ server {
   listen 80;
   listen [::]:80;
 
+  {% if use_lets_encrypt -%}
   server_name {{ certbot_domains | join(' ') }};
+  {% else -%}
+  server_name _;
+  {% endif %}
   root /home/{{ deploy_user }}/{{ app_name }}/current/public;
 
   passenger_enabled on;

--- a/vars/vars.yml
+++ b/vars/vars.yml
@@ -6,6 +6,7 @@ ruby_version: '2.6.6'
 app_name: 'cool'
 
 # TLS settings for Let's Encrypt
+use_lets_encrypt: false
 certbot_domains:
   - www.example.com
   - example.com

--- a/vars/vars.yml
+++ b/vars/vars.yml
@@ -5,6 +5,12 @@ ruby_version: '2.6.6'
 # Your rails app name
 app_name: 'cool'
 
+# TLS settings for Let's Encrypt
+certbot_domains:
+  - www.example.com
+  - example.com
+certbot_email: my_email@example.com
+
 deploy_user: 'deploy'
 deploy_user_password: 'correcthorsebatterystapler'
 


### PR DESCRIPTION
This PR is completely independent of the proposed changes in https://github.com/cupnoodle/rails-ansible/pull/1.

Implementation actually turned out to be fairly simple, mainly following the instructions in https://linuxbuz.com/linuxhowto/install-letsencrypt-ssl-ansible (with a few tweaks to simplify it and combine it with the existing playbook).

1. The user can specify one or more domains in `vars/vars.yml` along with an email address to register with
2. Certbot gets installed via apt
3. The domains from step 1 get merged into the Nginx config template (`templates/nginx_app.conf.j2`)
4. The domains and email address get used in one task to configure certbot and create the certificate
5. Another Ansible task adds a cron task to renew the certificates as required